### PR TITLE
feat(backend): add unit tests for domain entities

### DIFF
--- a/packages/backend/tests/ChoirApp.Domain.Tests/ChoirSongVersionTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/ChoirSongVersionTests.cs
@@ -1,0 +1,45 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class ChoirSongVersionTests
+{
+    [Fact]
+    public void ChoirSongVersion_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var choirSongId = Guid.NewGuid();
+        var masterSongId = Guid.NewGuid();
+        var choirId = Guid.NewGuid();
+        var editedLyricsChordPro = "{title: Edited Song}\nEdited lyrics content";
+        var lastEditedDate = DateTimeOffset.UtcNow;
+        var editorUserId = Guid.NewGuid();
+
+        // Act
+        var choirSongVersion = new ChoirSongVersion
+        {
+            ChoirSongId = choirSongId,
+            MasterSongId = masterSongId,
+            ChoirId = choirId,
+            EditedLyricsChordPro = editedLyricsChordPro,
+            LastEditedDate = lastEditedDate,
+            EditorUserId = editorUserId
+        };
+
+        // Assert
+        choirSongVersion.Should().NotBeNull();
+        choirSongVersion.ChoirSongId.Should().Be(choirSongId);
+        choirSongVersion.MasterSongId.Should().Be(masterSongId);
+        choirSongVersion.ChoirId.Should().Be(choirId);
+        choirSongVersion.EditedLyricsChordPro.Should().Be(editedLyricsChordPro);
+        choirSongVersion.LastEditedDate.Should().Be(lastEditedDate);
+        choirSongVersion.EditorUserId.Should().Be(editorUserId);
+        choirSongVersion.MasterSong.Should().BeNull(); // Navigation property should be null in unit test
+        choirSongVersion.Choir.Should().BeNull();     // Navigation property should be null in unit test
+        choirSongVersion.Editor.Should().BeNull();    // Navigation property should be null in unit test
+    }
+}
+

--- a/packages/backend/tests/ChoirApp.Domain.Tests/MasterSongTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/MasterSongTests.cs
@@ -1,0 +1,46 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+
+namespace ChoirApp.Domain.Tests;
+
+public class MasterSongTests
+{
+    [Fact]
+    public void MasterSong_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var songId = Guid.NewGuid();
+        var title = "Amazing Grace";
+        var artist = "John Newton";
+        var lyricsChordPro = "{title: Amazing Grace}\n{artist: John Newton}\nAmazing grace! How sweet the sound";
+
+        // Act
+        var masterSong = new MasterSong
+        {
+            SongId = songId,
+            Title = title,
+            Artist = artist,
+            LyricsChordPro = lyricsChordPro
+        };
+
+        // Assert
+        masterSong.Should().NotBeNull();
+        masterSong.SongId.Should().Be(songId);
+        masterSong.Title.Should().Be(title);
+        masterSong.Artist.Should().Be(artist);
+        masterSong.LyricsChordPro.Should().Be(lyricsChordPro);
+        masterSong.SongTags.Should().BeEmpty();
+        masterSong.ChoirSongVersions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MasterSong_Title_IsInitializedToEmptyString()
+    {
+        // Arrange & Act
+        var masterSong = new MasterSong();
+
+        // Assert
+        masterSong.Title.Should().Be(string.Empty);
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistSectionTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistSectionTests.cs
@@ -1,0 +1,57 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class PlaylistSectionTests
+{
+    [Fact]
+    public void PlaylistSection_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var sectionId = Guid.NewGuid();
+        var playlistId = Guid.NewGuid().ToString();
+        var title = "Warm-up Songs";
+        var orderIndex = 1;
+
+        // Act
+        var playlistSection = new PlaylistSection
+        {
+            SectionId = sectionId,
+            PlaylistId = playlistId,
+            Title = title,
+            OrderIndex = orderIndex
+        };
+
+        // Assert
+        playlistSection.Should().NotBeNull();
+        playlistSection.SectionId.Should().Be(sectionId);
+        playlistSection.PlaylistId.Should().Be(playlistId);
+        playlistSection.Title.Should().Be(title);
+        playlistSection.OrderIndex.Should().Be(orderIndex);
+        playlistSection.Playlist.Should().BeNull();
+        playlistSection.PlaylistSongs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PlaylistSection_Title_IsInitializedToEmptyString()
+    {
+        // Arrange & Act
+        var playlistSection = new PlaylistSection();
+
+        // Assert
+        playlistSection.Title.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void PlaylistSection_PlaylistId_IsInitializedToEmptyString()
+    {
+        // Arrange & Act
+        var playlistSection = new PlaylistSection();
+
+        // Assert
+        playlistSection.PlaylistId.Should().Be(string.Empty);
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistSongTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistSongTests.cs
@@ -1,0 +1,39 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class PlaylistSongTests
+{
+    [Fact]
+    public void PlaylistSong_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var playlistSongId = Guid.NewGuid();
+        var sectionId = Guid.NewGuid();
+        var songId = Guid.NewGuid();
+        var isMasterSong = true;
+        var orderIndex = 1;
+
+        // Act
+        var playlistSong = new PlaylistSong
+        {
+            PlaylistSongId = playlistSongId,
+            SectionId = sectionId,
+            SongId = songId,
+            IsMasterSong = isMasterSong,
+            OrderIndex = orderIndex
+        };
+
+        // Assert
+        playlistSong.Should().NotBeNull();
+        playlistSong.PlaylistSongId.Should().Be(playlistSongId);
+        playlistSong.SectionId.Should().Be(sectionId);
+        playlistSong.SongId.Should().Be(songId);
+        playlistSong.IsMasterSong.Should().Be(isMasterSong);
+        playlistSong.OrderIndex.Should().Be(orderIndex);
+        playlistSong.PlaylistSection.Should().BeNull();
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTagTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTagTests.cs
@@ -1,0 +1,41 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class PlaylistTagTests
+{
+    [Fact]
+    public void PlaylistTag_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid().ToString();
+        var tagId = Guid.NewGuid();
+
+        // Act
+        var playlistTag = new PlaylistTag
+        {
+            PlaylistId = playlistId,
+            TagId = tagId
+        };
+
+        // Assert
+        playlistTag.Should().NotBeNull();
+        playlistTag.PlaylistId.Should().Be(playlistId);
+        playlistTag.TagId.Should().Be(tagId);
+        playlistTag.Playlist.Should().BeNull();
+        playlistTag.Tag.Should().BeNull();
+    }
+
+    [Fact]
+    public void PlaylistTag_PlaylistId_IsInitializedToEmptyString()
+    {
+        // Arrange & Act
+        var playlistTag = new PlaylistTag();
+
+        // Assert
+        playlistTag.PlaylistId.Should().Be(string.Empty);
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTemplateSectionTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTemplateSectionTests.cs
@@ -1,0 +1,47 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class PlaylistTemplateSectionTests
+{
+    [Fact]
+    public void PlaylistTemplateSection_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var templateSectionId = Guid.NewGuid();
+        var templateId = Guid.NewGuid();
+        var title = "Opening Songs";
+        var orderIndex = 1;
+
+        // Act
+        var playlistTemplateSection = new PlaylistTemplateSection
+        {
+            TemplateSectionId = templateSectionId,
+            TemplateId = templateId,
+            Title = title,
+            OrderIndex = orderIndex
+        };
+
+        // Assert
+        playlistTemplateSection.Should().NotBeNull();
+        playlistTemplateSection.TemplateSectionId.Should().Be(templateSectionId);
+        playlistTemplateSection.TemplateId.Should().Be(templateId);
+        playlistTemplateSection.Title.Should().Be(title);
+        playlistTemplateSection.OrderIndex.Should().Be(orderIndex);
+        playlistTemplateSection.PlaylistTemplate.Should().BeNull();
+        playlistTemplateSection.PlaylistTemplateSongs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PlaylistTemplateSection_Title_IsInitializedToEmptyString()
+    {
+        // Arrange & Act
+        var playlistTemplateSection = new PlaylistTemplateSection();
+
+        // Assert
+        playlistTemplateSection.Title.Should().Be(string.Empty);
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTemplateSongTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTemplateSongTests.cs
@@ -1,0 +1,39 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class PlaylistTemplateSongTests
+{
+    [Fact]
+    public void PlaylistTemplateSong_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var templateSongId = Guid.NewGuid();
+        var templateSectionId = Guid.NewGuid();
+        var songId = Guid.NewGuid();
+        var isMasterSong = true;
+        var orderIndex = 1;
+
+        // Act
+        var playlistTemplateSong = new PlaylistTemplateSong
+        {
+            TemplateSongId = templateSongId,
+            TemplateSectionId = templateSectionId,
+            SongId = songId,
+            IsMasterSong = isMasterSong,
+            OrderIndex = orderIndex
+        };
+
+        // Assert
+        playlistTemplateSong.Should().NotBeNull();
+        playlistTemplateSong.TemplateSongId.Should().Be(templateSongId);
+        playlistTemplateSong.TemplateSectionId.Should().Be(templateSectionId);
+        playlistTemplateSong.SongId.Should().Be(songId);
+        playlistTemplateSong.IsMasterSong.Should().Be(isMasterSong);
+        playlistTemplateSong.OrderIndex.Should().Be(orderIndex);
+        playlistTemplateSong.PlaylistTemplateSection.Should().BeNull();
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTemplateTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTemplateTests.cs
@@ -1,0 +1,51 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class PlaylistTemplateTests
+{
+    [Fact]
+    public void PlaylistTemplate_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var templateId = Guid.NewGuid();
+        var choirId = Guid.NewGuid();
+        var title = "Mass Parts Template";
+        var description = "Standard template for mass parts.";
+        var creationDate = DateTimeOffset.UtcNow;
+
+        // Act
+        var playlistTemplate = new PlaylistTemplate
+        {
+            TemplateId = templateId,
+            ChoirId = choirId,
+            Title = title,
+            Description = description,
+            CreationDate = creationDate
+        };
+
+        // Assert
+        playlistTemplate.Should().NotBeNull();
+        playlistTemplate.TemplateId.Should().Be(templateId);
+        playlistTemplate.ChoirId.Should().Be(choirId);
+        playlistTemplate.Title.Should().Be(title);
+        playlistTemplate.Description.Should().Be(description);
+        playlistTemplate.CreationDate.Should().Be(creationDate);
+        playlistTemplate.Choir.Should().BeNull();
+        playlistTemplate.Playlists.Should().BeEmpty();
+        playlistTemplate.PlaylistTemplateSections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PlaylistTemplate_Title_IsInitializedToEmptyString()
+    {
+        // Arrange & Act
+        var playlistTemplate = new PlaylistTemplate();
+
+        // Assert
+        playlistTemplate.Title.Should().Be(string.Empty);
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/PlaylistTests.cs
@@ -1,0 +1,68 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class PlaylistTests
+{
+    [Fact]
+    public void Playlist_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var playlistId = Guid.NewGuid().ToString();
+        var choirId = Guid.NewGuid();
+        var title = "Sunday Service Playlist";
+        var description = "Songs for the upcoming Sunday service.";
+        var creationDate = DateTimeOffset.UtcNow;
+        var lastModifiedDate = DateTimeOffset.UtcNow;
+        var isPublic = true;
+
+        // Act
+        var playlist = new Playlist
+        {
+            PlaylistId = playlistId,
+            ChoirId = choirId,
+            Title = title,
+            Description = description,
+            CreationDate = creationDate,
+            LastModifiedDate = lastModifiedDate,
+            IsPublic = isPublic
+        };
+
+        // Assert
+        playlist.Should().NotBeNull();
+        playlist.PlaylistId.Should().Be(playlistId);
+        playlist.ChoirId.Should().Be(choirId);
+        playlist.Title.Should().Be(title);
+        playlist.Description.Should().Be(description);
+        playlist.CreationDate.Should().Be(creationDate);
+        playlist.LastModifiedDate.Should().Be(lastModifiedDate);
+        playlist.IsPublic.Should().Be(isPublic);
+        playlist.Choir.Should().BeNull();
+        playlist.PlaylistTemplate.Should().BeNull();
+        playlist.PlaylistSections.Should().BeEmpty();
+        playlist.PlaylistTags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Playlist_Title_IsInitializedToEmptyString()
+    {
+        // Arrange & Act
+        var playlist = new Playlist();
+
+        // Assert
+        playlist.Title.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void Playlist_PlaylistId_IsInitializedToEmptyString()
+    {
+        // Arrange & Act
+        var playlist = new Playlist();
+
+        // Assert
+        playlist.PlaylistId.Should().Be(string.Empty);
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/SongTagTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/SongTagTests.cs
@@ -1,0 +1,31 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class SongTagTests
+{
+    [Fact]
+    public void SongTag_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var songId = Guid.NewGuid();
+        var tagId = Guid.NewGuid();
+
+        // Act
+        var songTag = new SongTag
+        {
+            SongId = songId,
+            TagId = tagId
+        };
+
+        // Assert
+        songTag.Should().NotBeNull();
+        songTag.SongId.Should().Be(songId);
+        songTag.TagId.Should().Be(tagId);
+        songTag.MasterSong.Should().BeNull();
+        songTag.Tag.Should().BeNull();
+    }
+}

--- a/packages/backend/tests/ChoirApp.Domain.Tests/UserChoirTests.cs
+++ b/packages/backend/tests/ChoirApp.Domain.Tests/UserChoirTests.cs
@@ -1,0 +1,31 @@
+using ChoirApp.Domain.Entities;
+using Xunit;
+using FluentAssertions;
+using System;
+
+namespace ChoirApp.Domain.Tests;
+
+public class UserChoirTests
+{
+    [Fact]
+    public void UserChoir_CanBeCreated_WithValidData()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var choirId = Guid.NewGuid();
+
+        // Act
+        var userChoir = new UserChoir
+        {
+            UserId = userId,
+            ChoirId = choirId
+        };
+
+        // Assert
+        userChoir.Should().NotBeNull();
+        userChoir.UserId.Should().Be(userId);
+        userChoir.ChoirId.Should().Be(choirId);
+        userChoir.User.Should().BeNull();
+        userChoir.Choir.Should().BeNull();
+    }
+}


### PR DESCRIPTION
This commit introduces comprehensive unit tests for several domain entities that previously lacked dedicated test coverage. The newly added tests ensure the correctness and integrity of the core business logic for the following entities:

- `MasterSong`
- `ChoirSongVersion`
- `Playlist`
- `PlaylistSection`
- `PlaylistSong`
- `PlaylistTag`
- `PlaylistTemplate`
- `PlaylistTemplateSection`
- `PlaylistTemplateSong`
- `SongTag`
- `UserChoir`

Each test file includes basic creation tests and verifies property initialization, significantly improving the overall unit test coverage for the `ChoirApp.Domain` layer.