### PR TITLE
feat: implement admin dashboard navigation

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import CreateMasterSongPage from './pages/CreateMasterSongPage.tsx';
 import MasterSongDetailPage from './pages/MasterSongDetailPage.tsx';
 import ChoirSongsListPage from './pages/ChoirSongsListPage.tsx';
 import ChoirSongEditorPage from './pages/ChoirSongEditorPage.tsx';
+import ChoirAdminPage from './pages/ChoirAdminPage.tsx';
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
       <Route path="/master-songs/create" element={<CreateMasterSongPage />} />
       <Route path="/master-songs/:id" element={<MasterSongDetailPage />} />
       <Route path="/choir-songs" element={<ChoirSongsListPage />} />
+      <Route path="/choir/:choirId/admin" element={<ChoirAdminPage />} />
       <Route path="/choirs/:choirId/songs/:songId/edit" element={<ChoirSongEditorPage />} />
     </Routes>
   );

--- a/packages/frontend/src/pages/ChoirAdminPage.tsx
+++ b/packages/frontend/src/pages/ChoirAdminPage.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+const ChoirAdminPage: React.FC = () => {
+  const { choirId } = useParams<{ choirId: string }>();
+
+  return (
+    <section className="section">
+      <div className="container">
+        <div className="level">
+          <div className="level-left">
+            <h1 className="title">Choir Admin</h1>
+          </div>
+          <div className="level-right">
+            <Link to="/dashboard" className="button">
+              Go Back to Dashboard
+            </Link>
+          </div>
+        </div>
+        <p>This is the admin page for choir {choirId}.</p>
+      </div>
+    </section>
+  );
+};
+
+export default ChoirAdminPage;

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -61,7 +61,7 @@ const DashboardPage: React.FC = () => {
               <div className="list">
                 {adminOfChoirs.map(choir => (
                   <div key={choir.id} className="list-item">
-                    <Link to={`/choir/${choir.id}`}>{choir.name}</Link>
+                    <Link to={`/choir/${choir.id}/admin`}>{choir.name}</Link>
                   </div>
                 ))}
               </div>

--- a/packages/frontend/tests/integration/AdminDashboardFlow.test.tsx
+++ b/packages/frontend/tests/integration/AdminDashboardFlow.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, test, expect } from 'vitest';
+import DashboardPage from '../../src/pages/DashboardPage';
+import ChoirAdminPage from '../../src/pages/ChoirAdminPage';
+import { UserContext, UserContextType } from '../../src/contexts/UserContext';
+import { User } from '../../src/types/user';
+import '@testing-library/jest-dom';
+
+describe('Admin Dashboard Flow', () => {
+  const adminUser: User = {
+    id: '1',
+    name: 'Admin User',
+    email: 'admin@example.com',
+    choirs: [
+      { id: 'choir-1', name: 'Admin Choir', role: 'Admin' },
+      { id: 'choir-2', name: 'Member Choir', role: 'Member' },
+    ],
+    hasCompletedOnboarding: true,
+    role: 'General',
+    isNewUser: false,
+  };
+
+  const userContextValue: UserContextType = {
+    user: adminUser,
+    loading: false,
+    token: 'test-token',
+    refetchUser: async () => {},
+  };
+
+  test('clicking on an admin choir navigates to the choir admin page and back', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <UserContext.Provider value={userContextValue}>
+          <Routes>
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/choir/:choirId/admin" element={<ChoirAdminPage />} />
+          </Routes>
+        </UserContext.Provider>
+      </MemoryRouter>
+    );
+
+    // Navigate to admin page
+    const adminChoirLink = screen.getByText('Admin Choir');
+    await user.click(adminChoirLink);
+
+    await waitFor(() => {
+      expect(screen.getByText(/This is the admin page for choir choir-1/)).toBeInTheDocument();
+    });
+
+    // Navigate back to dashboard
+    const goBackButton = screen.getByText('Go Back to Dashboard');
+    await user.click(goBackButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Choirs (Admin)')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Adds a new route and page for the choir admin dashboard. Updates the main dashboard to link to the admin dashboard for choirs where the user is an admin. Also adds a 'Go Back' button to the admin dashboard to navigate back to the main dashboard.